### PR TITLE
[Feat] Member 엔티티 생성 (#2)

### DIFF
--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Member.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Member.java
@@ -2,11 +2,15 @@ package github.nbcamp.lectureflow.global.entity;
 
 import github.nbcamp.lectureflow.domain.user.enums.Role;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;//추가
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)//추가
 @Table(name = "members")
+
 public class Member extends BaseEntity {
 
     //고유 식별자
@@ -54,10 +58,5 @@ public class Member extends BaseEntity {
     public void updateInfo(String name, String phone) {
         this.name = name;
         this.phone = phone;
-    }
-
-    //관리자 여부 확인
-    public boolean isAdmin() {
-        return this.role == Role.ADMIN;
     }
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Member.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Member.java
@@ -1,0 +1,63 @@
+package github.nbcamp.lectureflow.global.entity;
+
+import github.nbcamp.lectureflow.domain.user.enums.Role;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "members")
+public class Member extends BaseEntity {
+
+    //고유 식별자
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //이메일
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    //비밀번호
+    @Column(nullable = false)
+    private String password;
+
+    //사용자 이름
+    @Column(nullable = false)
+    private String name;
+
+    //전화번호 (선택)
+    private String phone;
+
+    //권한: ADMIN / STUDENT
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    //정적 팩토리 메서드
+    public static Member of(String email, String password, String name, String phone, Role role) {
+        Member member = new Member();
+        member.email = email;
+        member.password = password;
+        member.name = name;
+        member.phone = phone;
+        member.role = role;
+        return member;
+    }
+
+    //비밀번호 수정
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    //이름 및 전화번호 수정
+    public void updateInfo(String name, String phone) {
+        this.name = name;
+        this.phone = phone;
+    }
+
+    //관리자 여부 확인
+    public boolean isAdmin() {
+        return this.role == Role.ADMIN;
+    }
+}


### PR DESCRIPTION
## 이슈 번호
Closes #2
## 작업 내용
- Member 엔티티 생성 및 필드 정의(email, password, name, phone, role)
- Role enum 연동 (domain.user.enums.Role)
- BaseEntity 상속 (createdAt, updatedAt, deleted 필드)
- 정적 팩토리 메서드 `create()` 방식 적용
- 연관관계(LectureMember)는 추후 별도 이슈로 처리 예정

## 스크린샷(선택)
(없음)