### PR TITLE
Feat: LectureMember Entity 구현(#3)

### DIFF
--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
@@ -28,4 +28,13 @@ public class LectureMember extends BaseEntity {
     // 재수강 여부
     @Column(nullable=false)
     private boolean isRetake=false;
+
+    //정적 팩토리 메서드
+    public static LectureMember of(Member member, Lecture lecture, boolean isRetake) {
+        LectureMember lectureMember = new LectureMember();
+        lectureMember.member = member;
+        lectureMember.lecture = lecture;
+        lectureMember.isRetake = isRetake;
+        return lectureMember;
+    }
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
@@ -27,14 +27,24 @@ public class LectureMember extends BaseEntity {
 
     // 재수강 여부
     @Column(nullable=false)
-    private boolean isRetake=false;
+    private boolean isRetake;
 
-    //정적 팩토리 메서드
-    public static LectureMember of(Member member, Lecture lecture, boolean isRetake) {
+    /**
+     * 정적 팩토리 메서드
+     * 재수강 여부는 기본적으로 false.
+     */
+    public static LectureMember of(Member member, Lecture lecture) {
         LectureMember lectureMember = new LectureMember();
         lectureMember.member = member;
         lectureMember.lecture = lecture;
-        lectureMember.isRetake = isRetake;
+        lectureMember.isRetake=false;
         return lectureMember;
+    }
+
+    /**
+     *     재수강인 경우 true로 변경(default false)
+     */
+    public void updateRetake(){
+        this.isRetake=true;
     }
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
@@ -1,0 +1,31 @@
+package github.nbcamp.lectureflow.global.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LectureMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    //수강신청 내역 고유 ID
+    private Long id;
+
+    //학생(member)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    //강의 (lecture)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id", nullable = false)
+    private Lecture lecture;
+
+    // 재수강 여부
+    @Column(nullable=false)
+    private boolean isRetake=false;
+}


### PR DESCRIPTION
## 이슈 번호
#3
## 작업 내용
- LectureMember Entity 구현
    - ManyToOne 연관관계 설정(Member, Lecture)
    - isRetake 필드 추가(재수강 여부, default false)
    - BaseEntity 상속
    - 정적 팩토리 메서드 추가
    - updateRetake() 메서드 추가 (재수강인 경우 true로 변환하는 메서드)
## 스크린샷(선택)