### PR TITLE
Feat: 회원가입, 로그인 API 구현 (#7)

### DIFF
--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/controller/AuthController.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/controller/AuthController.java
@@ -1,0 +1,36 @@
+package github.nbcamp.lectureflow.domain.auth.controller;
+
+
+import github.nbcamp.lectureflow.domain.auth.dto.request.SigninRequest;
+import github.nbcamp.lectureflow.domain.auth.dto.request.SignupRequest;
+import github.nbcamp.lectureflow.domain.auth.dto.response.SigninResponse;
+import github.nbcamp.lectureflow.domain.auth.dto.response.SignupResponse;
+import github.nbcamp.lectureflow.domain.auth.service.AuthService;
+import github.nbcamp.lectureflow.global.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
+        Long memberId = authService.signup(request);
+        return ResponseEntity.ok(ApiResponse.success("회원가입 성공", SignupResponse.of(memberId)));
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<ApiResponse<SigninResponse>> signin(@Valid @RequestBody SigninRequest request) {
+        SigninResponse response = authService.signin(request);
+        return ResponseEntity.ok(ApiResponse.success("로그인 성공", SigninResponse.of(response.getMemberId(), response.getToken())));
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/controller/AuthController.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/controller/AuthController.java
@@ -24,13 +24,13 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
-        Long memberId = authService.signup(request);
-        return ResponseEntity.ok(ApiResponse.success("회원가입 성공", SignupResponse.of(memberId)));
+        SignupResponse response = authService.signup(request);
+        return ResponseEntity.ok(ApiResponse.success("회원가입 성공", response));
     }
 
     @PostMapping("/signin")
     public ResponseEntity<ApiResponse<SigninResponse>> signin(@Valid @RequestBody SigninRequest request) {
         SigninResponse response = authService.signin(request);
-        return ResponseEntity.ok(ApiResponse.success("로그인 성공", SigninResponse.of(response.getMemberId(), response.getToken())));
+        return ResponseEntity.ok(ApiResponse.success("로그인 성공", response));
     }
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/request/SigninRequest.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/request/SigninRequest.java
@@ -1,0 +1,17 @@
+package github.nbcamp.lectureflow.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SigninRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    private final String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private final String password;
+
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/request/SignupRequest.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/request/SignupRequest.java
@@ -1,0 +1,27 @@
+package github.nbcamp.lectureflow.domain.auth.dto.request;
+
+import github.nbcamp.lectureflow.domain.user.enums.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    private final String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private final String password;
+
+    @NotBlank(message = "사용자 이름은 필수입니다.")
+    private final String name;
+
+    private final String phone;
+
+    @NotNull(message = "역할은 필수입니다.")
+    private final Role role;
+
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/response/SigninResponse.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/response/SigninResponse.java
@@ -1,0 +1,16 @@
+package github.nbcamp.lectureflow.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SigninResponse {
+
+    private final Long memberId;
+    private final String token;
+
+    public static SigninResponse of(Long memberId, String token) {
+        return new SigninResponse(memberId, token);
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/response/SignupResponse.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/response/SignupResponse.java
@@ -1,0 +1,15 @@
+package github.nbcamp.lectureflow.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupResponse {
+
+    private final Long memberId;
+
+    public static SignupResponse of(Long memberId) {
+        return new SignupResponse(memberId);
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/exception/AuthException.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/exception/AuthException.java
@@ -1,0 +1,12 @@
+package github.nbcamp.lectureflow.domain.auth.exception;
+
+import github.nbcamp.lectureflow.global.exception.CustomException;
+import github.nbcamp.lectureflow.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends CustomException {
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/repository/AuthRepository.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/repository/AuthRepository.java
@@ -1,0 +1,12 @@
+package github.nbcamp.lectureflow.domain.auth.repository;
+
+import github.nbcamp.lectureflow.global.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AuthRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/service/AuthService.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/service/AuthService.java
@@ -3,9 +3,10 @@ package github.nbcamp.lectureflow.domain.auth.service;
 import github.nbcamp.lectureflow.domain.auth.dto.request.SigninRequest;
 import github.nbcamp.lectureflow.domain.auth.dto.request.SignupRequest;
 import github.nbcamp.lectureflow.domain.auth.dto.response.SigninResponse;
+import github.nbcamp.lectureflow.domain.auth.dto.response.SignupResponse;
 
 public interface AuthService {
-    Long signup(SignupRequest request);
+    SignupResponse signup(SignupRequest request);
 
     SigninResponse signin(SigninRequest request);
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/service/AuthService.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/service/AuthService.java
@@ -1,0 +1,11 @@
+package github.nbcamp.lectureflow.domain.auth.service;
+
+import github.nbcamp.lectureflow.domain.auth.dto.request.SigninRequest;
+import github.nbcamp.lectureflow.domain.auth.dto.request.SignupRequest;
+import github.nbcamp.lectureflow.domain.auth.dto.response.SigninResponse;
+
+public interface AuthService {
+    Long signup(SignupRequest request);
+
+    SigninResponse signin(SigninRequest request);
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImpl.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,56 @@
+package github.nbcamp.lectureflow.domain.auth.service;
+
+import github.nbcamp.lectureflow.domain.auth.dto.request.SigninRequest;
+import github.nbcamp.lectureflow.domain.auth.dto.request.SignupRequest;
+import github.nbcamp.lectureflow.domain.auth.dto.response.SigninResponse;
+import github.nbcamp.lectureflow.domain.auth.exception.AuthException;
+import github.nbcamp.lectureflow.domain.auth.repository.AuthRepository;
+import github.nbcamp.lectureflow.global.entity.Member;
+import github.nbcamp.lectureflow.global.exception.ErrorCode;
+import github.nbcamp.lectureflow.global.filter.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final AuthRepository authRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    @Transactional
+    public Long signup(SignupRequest request) {
+        if (authRepository.existsByEmail(request.getEmail())) {
+            throw new AuthException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        Member member = Member.of(
+                request.getEmail(),
+                passwordEncoder.encode(request.getPassword()),
+                request.getName(),
+                request.getPhone(),
+                request.getRole()
+        );
+
+        Member saved = authRepository.save(member);
+        return saved.getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SigninResponse signin(SigninRequest request) {
+        Member member = authRepository.findByEmail(request.getEmail()).orElseThrow(() -> new AuthException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new AuthException(ErrorCode.PASSWORD_MISMATCH);
+        }
+
+        String token = jwtUtil.generateToken(member.getId(), member.getName(), member.getRole());
+
+        return SigninResponse.of(member.getId(), token);
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImpl.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package github.nbcamp.lectureflow.domain.auth.service;
 import github.nbcamp.lectureflow.domain.auth.dto.request.SigninRequest;
 import github.nbcamp.lectureflow.domain.auth.dto.request.SignupRequest;
 import github.nbcamp.lectureflow.domain.auth.dto.response.SigninResponse;
+import github.nbcamp.lectureflow.domain.auth.dto.response.SignupResponse;
 import github.nbcamp.lectureflow.domain.auth.exception.AuthException;
 import github.nbcamp.lectureflow.domain.auth.repository.AuthRepository;
 import github.nbcamp.lectureflow.global.entity.Member;
@@ -23,7 +24,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public Long signup(SignupRequest request) {
+    public SignupResponse signup(SignupRequest request) {
         if (authRepository.existsByEmail(request.getEmail())) {
             throw new AuthException(ErrorCode.DUPLICATE_EMAIL);
         }
@@ -37,7 +38,7 @@ public class AuthServiceImpl implements AuthService {
         );
 
         Member saved = authRepository.save(member);
-        return saved.getId();
+        return SignupResponse.of(saved.getId());
     }
 
     @Override

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/exception/ErrorCode.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/exception/ErrorCode.java
@@ -10,7 +10,14 @@ public enum ErrorCode {
 
     // 공통
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상하지 못한 에러"),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근권한이 없습니다.");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근권한이 없습니다."),
+
+    // auth
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "사용중인 이메일 입니다."),
+    PASSWORD_MISMATCH(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),
+
+    // member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String msg;

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/filter/JwtFilter.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/filter/JwtFilter.java
@@ -50,11 +50,11 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private void setSecurityContextHolder(String jwt) {
 
-        Long userId = jwtUtil.extractUserId(jwt);
-        String userRole = jwtUtil.extractRoles(jwt);
+        Long memberId = jwtUtil.extractMemberId(jwt);
+        String role = jwtUtil.extractRoles(jwt);
 
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
-                userId, "", List.of(new SimpleGrantedAuthority("ROLE_" + userRole))
+                memberId, "", List.of(new SimpleGrantedAuthority("ROLE_" + role))
         ));
     }
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/filter/JwtUtil.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/filter/JwtUtil.java
@@ -23,8 +23,11 @@ public class JwtUtil {
     private long TOKEN_TIME;
     private Key key;
 
+    @Value("${app.jwt-secret}")
+    private String secretKey;
+
     @PostConstruct
-    public void init(@Value("${app.jwt-secret}") String secretKey) {
+    public void init() {
         byte[] bytes = Base64.getDecoder().decode(secretKey);
         key = Keys.hmacShaKeyFor(bytes);
     }
@@ -36,12 +39,12 @@ public class JwtUtil {
                 .getBody();
     }
 
-    public String generateToken(Long userId, String username, Role memberRole) {
+    public String generateToken(Long memberId, String name, Role memberRole) {
         Date date = new Date();
 
         return Jwts.builder()
-                .setSubject(username)
-                .claim("userId", userId)
+                .setSubject(name)
+                .claim("memberId", memberId)
                 .claim("auth", memberRole)
                 .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                 .setIssuedAt(date)
@@ -49,8 +52,8 @@ public class JwtUtil {
                 .compact();
     }
 
-    public Long extractUserId(String token) {
-        return extractAllClaims(token).get("userId", Long.class);
+    public Long extractMemberId(String token) {
+        return extractAllClaims(token).get("memberId", Long.class);
     }
 
     public String extractRoles(String token) {

--- a/LectureFlow/src/test/java/github/nbcamp/lectureflow/domain/auth/repository/AuthRepositoryTest.java
+++ b/LectureFlow/src/test/java/github/nbcamp/lectureflow/domain/auth/repository/AuthRepositoryTest.java
@@ -1,0 +1,41 @@
+package github.nbcamp.lectureflow.domain.auth.repository;
+
+import github.nbcamp.lectureflow.domain.user.enums.Role;
+import github.nbcamp.lectureflow.global.entity.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AuthRepositoryTest {
+
+    @Autowired
+    private AuthRepository authRepository;
+
+    @Test
+    void 이메일로_멤버_조회_테스트() {
+        // given
+        Member member = Member.of("test@email.com", "testPassword", "testName", "010-1234-1234", Role.STUDENT);
+        authRepository.save(member);
+        // when
+        Member member1 = authRepository.findByEmail("test@email.com").orElseThrow();
+        // then
+        assertEquals(member.getEmail(), member1.getEmail());
+    }
+
+    @Test
+    void 존재하는_이메일인지_확인() {
+        // given
+        Member member = Member.of("test@email.com", "testPassword", "testName", "010-1234-1234", Role.STUDENT);
+        authRepository.save(member);
+        // when
+        boolean existsByEmail = authRepository.existsByEmail("test@email.com");
+        // then
+        assertTrue(existsByEmail);
+    }
+
+}

--- a/LectureFlow/src/test/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImplTest.java
+++ b/LectureFlow/src/test/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImplTest.java
@@ -3,6 +3,7 @@ package github.nbcamp.lectureflow.domain.auth.service;
 import github.nbcamp.lectureflow.domain.auth.dto.request.SigninRequest;
 import github.nbcamp.lectureflow.domain.auth.dto.request.SignupRequest;
 import github.nbcamp.lectureflow.domain.auth.dto.response.SigninResponse;
+import github.nbcamp.lectureflow.domain.auth.dto.response.SignupResponse;
 import github.nbcamp.lectureflow.domain.auth.exception.AuthException;
 import github.nbcamp.lectureflow.domain.auth.repository.AuthRepository;
 import github.nbcamp.lectureflow.domain.user.enums.Role;
@@ -45,9 +46,9 @@ class AuthServiceImplTest {
         given(authRepository.save(any())).willReturn(member);
         given(passwordEncoder.encode(anyString())).willReturn("encodedPassword");
         // when
-        Long signup = authService.signup(request);
+        SignupResponse response = authService.signup(request);
         // then
-        assertNotNull(signup);
+        assertNotNull(response);
     }
 
     @Test

--- a/LectureFlow/src/test/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImplTest.java
+++ b/LectureFlow/src/test/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImplTest.java
@@ -1,0 +1,93 @@
+package github.nbcamp.lectureflow.domain.auth.service;
+
+import github.nbcamp.lectureflow.domain.auth.dto.request.SigninRequest;
+import github.nbcamp.lectureflow.domain.auth.dto.request.SignupRequest;
+import github.nbcamp.lectureflow.domain.auth.dto.response.SigninResponse;
+import github.nbcamp.lectureflow.domain.auth.exception.AuthException;
+import github.nbcamp.lectureflow.domain.auth.repository.AuthRepository;
+import github.nbcamp.lectureflow.domain.user.enums.Role;
+import github.nbcamp.lectureflow.global.entity.Member;
+import github.nbcamp.lectureflow.global.filter.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplTest {
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+    @Mock
+    private AuthRepository authRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Test
+    void 회원가입에_성공한다() {
+        // given
+        SignupRequest request = new SignupRequest("test@email.com", "testPassword", "testName", "010-1234-1234", Role.STUDENT);
+        Member member = mock();
+        ReflectionTestUtils.setField(member, "id", 1L);
+        given(authRepository.save(any())).willReturn(member);
+        given(passwordEncoder.encode(anyString())).willReturn("encodedPassword");
+        // when
+        Long signup = authService.signup(request);
+        // then
+        assertNotNull(signup);
+    }
+
+    @Test
+    void 로그인에_성공한다() {
+        // given
+        SigninRequest request = new SigninRequest("test@email.com", "testPassword");
+        Member member = Member.of("test@email.com", "encodedPassword", "testName", "010-1234-1234", Role.STUDENT);
+        ReflectionTestUtils.setField(member, "id", 1L);
+
+        given(authRepository.findByEmail(request.getEmail())).willReturn(Optional.of(member));
+        given(passwordEncoder.matches(request.getPassword(), member.getPassword())).willReturn(true);
+        given(jwtUtil.generateToken(member.getId(), member.getName(), member.getRole())).willReturn("testToken");
+
+        // when
+        SigninResponse response = authService.signin(request);
+
+        // then
+        assertNotNull(response);
+        assertEquals(1L, response.getMemberId());
+        assertEquals("testToken", response.getToken());
+    }
+
+    @Test
+    void 이미_등록된_이메일로_회원가입하면_예외가_발생한다() {
+        // given
+        SignupRequest request = new SignupRequest("test@email.com", "testPassword", "testName", "010-1234-1234", Role.STUDENT);
+        given(authRepository.existsByEmail(request.getEmail())).willReturn(true);
+
+        // when & then
+        assertThrows(AuthException.class, () -> authService.signup(request));
+    }
+
+    @Test
+    void 이메일로_회원_조회시_존재하지_않으면_예외가_발생한다() {
+        // given
+        SigninRequest request = new SigninRequest("notfound@email.com", "anyPassword");
+        given(authRepository.findByEmail(request.getEmail())).willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(AuthException.class, () -> authService.signin(request));
+    }
+
+}


### PR DESCRIPTION
## 이슈 번호
#7 

## 작업 내용
- 회원가입, 로그인 요청, 응답 DTO 생성
- user->member 변수이름 변경
- Auth에서 발생하는 에러코드 추가
- 회원가입, 로그인 API 구현

## 스크린샷(선택)