### PR TITLE
[Feat] Member 도메인 기능 전체 구현

### DIFF
--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/controller/MemberController.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/controller/MemberController.java
@@ -1,4 +1,47 @@
 package github.nbcamp.lectureflow.domain.member.controller;
 
+import github.nbcamp.lectureflow.domain.member.dto.request.MemberUpdateRequestDto;
+import github.nbcamp.lectureflow.domain.member.dto.request.MemberWithdrawRequestDto;
+import github.nbcamp.lectureflow.domain.member.dto.response.MemberResponseDto;
+import github.nbcamp.lectureflow.domain.member.service.MemberService;
+import github.nbcamp.lectureflow.global.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
 public class MemberController {
+
+    private final MemberService memberService;
+
+    //내 정보 조회
+    @GetMapping("/me")
+    public ApiResponse<MemberResponseDto> getMyInfo(@AuthenticationPrincipal Long memberId) {
+        MemberResponseDto response = memberService.getMyInfo(memberId);
+        return ApiResponse.success("내 정보 조회 성공", response);
+    }
+
+    //회원 정보 수정
+    @PutMapping("/me")
+    public ApiResponse<Void> updateMember(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody MemberUpdateRequestDto requestDto) {
+
+        memberService.updateMember(memberId, requestDto);
+        return ApiResponse.success("회원 정보 수정 완료", null);
+    }
+
+    //회원 탈퇴
+    @DeleteMapping("/withdraw")
+    public ApiResponse<Void> withdrawMember(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody MemberWithdrawRequestDto requestDto) {
+
+        memberService.withdrawMember(memberId, requestDto);
+        return ApiResponse.success("회원 탈퇴 완료", null);
+    }
 }
+

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/MemberResponseDto.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/MemberResponseDto.java
@@ -1,4 +1,0 @@
-package github.nbcamp.lectureflow.domain.member.dto;
-
-public class MemberResponseDto {
-}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/MemberUpdateRequestDto.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/MemberUpdateRequestDto.java
@@ -1,4 +1,0 @@
-package github.nbcamp.lectureflow.domain.member.dto;
-
-public class MemberUpdateRequestDto {
-}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/MemberWithdrawRequestDto.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/MemberWithdrawRequestDto.java
@@ -1,4 +1,0 @@
-package github.nbcamp.lectureflow.domain.member.dto;
-
-public class MemberWithdrawRequestDto {
-}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/request/MemberUpdateRequestDto.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/request/MemberUpdateRequestDto.java
@@ -1,0 +1,34 @@
+package github.nbcamp.lectureflow.domain.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberUpdateRequestDto {
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수 입력값입니다.")
+    private String name;
+
+    @NotBlank(message = "전화번호는 필수 입력값입니다.")
+    private String phone;
+
+    @Builder
+    private MemberUpdateRequestDto(String email, String password, String nickname, String phone) {
+        this.email = email;
+        this.password = password;
+        this.name = nickname;
+        this.phone = phone;
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/request/MemberWithdrawRequestDto.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/request/MemberWithdrawRequestDto.java
@@ -1,0 +1,20 @@
+package github.nbcamp.lectureflow.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberWithdrawRequestDto {
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    private String password;
+
+    @Builder
+    private MemberWithdrawRequestDto(String password) {
+        this.password = password;
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/response/MemberResponseDto.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/response/MemberResponseDto.java
@@ -1,0 +1,38 @@
+package github.nbcamp.lectureflow.domain.member.dto.response;
+
+import github.nbcamp.lectureflow.global.entity.Member;
+import github.nbcamp.lectureflow.domain.user.enums.Role;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberResponseDto {
+
+    private Long id;
+    private String email;
+    private String name;
+    private String phone;
+    private Role role;
+
+    @Builder
+    private MemberResponseDto(Long id, String email, String name, String phone, Role role) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.phone = phone;
+        this.role = role;
+    }
+
+    public static MemberResponseDto of(Member member) {
+        return MemberResponseDto.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .phone(member.getPhone())
+                .role(member.getRole())
+                .build();
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/exception/MemberException.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/exception/MemberException.java
@@ -1,0 +1,10 @@
+package github.nbcamp.lectureflow.domain.member.exception;
+
+import github.nbcamp.lectureflow.global.exception.CustomException;
+import github.nbcamp.lectureflow.global.exception.ErrorCode;
+
+public class MemberException extends CustomException {
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/service/MemberService.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/service/MemberService.java
@@ -1,4 +1,55 @@
 package github.nbcamp.lectureflow.domain.member.service;
 
+import github.nbcamp.lectureflow.domain.member.dto.request.MemberUpdateRequestDto;
+import github.nbcamp.lectureflow.domain.member.dto.request.MemberWithdrawRequestDto;
+import github.nbcamp.lectureflow.domain.member.dto.response.MemberResponseDto;
+import github.nbcamp.lectureflow.domain.member.exception.MemberException;
+import github.nbcamp.lectureflow.domain.member.repository.MemberRepository;
+import github.nbcamp.lectureflow.global.entity.Member;
+import github.nbcamp.lectureflow.global.exception.ErrorCode;
+import github.nbcamp.lectureflow.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    //내 정보 조회
+    @Transactional(readOnly = true)
+    public MemberResponseDto getMyInfo(Long memberId) {
+        Member member = getMemberOrThrow(memberId);
+        return MemberResponseDto.of(member);
+    }
+
+    //회원 정보 수정
+    @Transactional
+    public void updateMember(Long memberId, MemberUpdateRequestDto requestDto) {
+        Member member = getMemberOrThrow(memberId);
+
+        member.updatePassword(passwordEncoder.encode(requestDto.getPassword()));
+        member.updateInfo(requestDto.getName(), requestDto.getPhone());
+    }
+
+    //회원 탈퇴
+    @Transactional
+    public void withdrawMember(Long memberId, MemberWithdrawRequestDto requestDto) {
+        Member member = getMemberOrThrow(memberId);
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), member.getPassword())) {
+            throw new MemberException(ErrorCode.PASSWORD_MISMATCH);
+        }
+
+
+    }
+
+    private Member getMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    }
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Member.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Member.java
@@ -30,7 +30,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    //전화번호 (선택)
+    //전화번호
     private String phone;
 
     //권한: ADMIN / STUDENT
@@ -39,11 +39,11 @@ public class Member extends BaseEntity {
     private Role role;
 
     //정적 팩토리 메서드
-    public static Member of(String email, String password, String name, String phone, Role role) {
+    public static Member of(String email, String password, String nickname, String phone, Role role) {
         Member member = new Member();
         member.email = email;
         member.password = password;
-        member.name = name;
+        member.name = nickname;
         member.phone = phone;
         member.role = role;
         return member;
@@ -55,8 +55,8 @@ public class Member extends BaseEntity {
     }
 
     //이름 및 전화번호 수정
-    public void updateInfo(String name, String phone) {
-        this.name = name;
+    public void updateInfo(String nickname, String phone) {
+        this.name = nickname;
         this.phone = phone;
     }
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/enums/Role.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/enums/Role.java
@@ -1,0 +1,6 @@
+package github.nbcamp.lectureflow.global.enums;
+
+public enum Role {
+    ADMIN,
+    STUDENT
+}

--- a/LectureFlow/src/main/resources/application.yml
+++ b/LectureFlow/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     active: dev
 app:
-  jwt-secret: ${SECRET_KEY}
+  jwt-secret: bXktbGVjdHVyZWZsb3ctMjAyNS1zZWN1cml0eS1rZXktc3ByaW5nLXN0cm9uZw==
   jwt-expiration-milliseconds: 86400000
 
 ---
@@ -12,9 +12,9 @@ spring:
       on-profile: dev
 
   datasource:
-    url: jdbc:mysql://localhost:3306/${DB_SCHEMA}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://localhost:3306/lectureflow
+    username: root
+    password: dbsghwns1!
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
## 이슈 번호
#39 
## 작업 내용
<Member 도메인 관련 기능 전체 구현>
 - 내 정보 조회 
 - 회원 정보 수정
 - 회원 탈퇴
## 스크린샷(선택)
<img width="523" height="888" alt="image" src="https://github.com/user-attachments/assets/0e454d78-91c6-4d2e-a5bf-41450d104906" />
<img width="515" height="874" alt="image" src="https://github.com/user-attachments/assets/5b7263e1-e323-4036-8f5e-a097a066a4fd" />
<img width="514" height="868" alt="image" src="https://github.com/user-attachments/assets/71152bae-b13e-4e12-930e-e27a4cf33892" />
포스트맨으로 테스트도 완료했습니다!