### PR TITLE
Feat: 자신이 수강신청한 목록 조회, 특정 강의 수강신청 인원 조회  (#20, #21)

### DIFF
--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/controller/LectureMemberController.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/controller/LectureMemberController.java
@@ -3,6 +3,7 @@ package github.nbcamp.lectureflow.domain.lectureMember.controller;
 
 import github.nbcamp.lectureflow.domain.lectureMember.dto.request.CreateLectureMemberRequest;
 import github.nbcamp.lectureflow.domain.lectureMember.dto.response.CreateLectureMemberResponse;
+import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureEnrollCountResponse;
 import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureMemberListResponse;
 import github.nbcamp.lectureflow.domain.lectureMember.service.LectureMemberQueryService;
 import github.nbcamp.lectureflow.domain.lectureMember.service.LectureMemberService;
@@ -28,6 +29,13 @@ public class LectureMemberController {
     public ResponseEntity<ApiResponse<List<LectureMemberListResponse>>> getLectureMember(@AuthenticationPrincipal Long memberId) {
         List<LectureMemberListResponse> response = lectureMemberQueryService.getLectureMember(memberId);
         return ResponseEntity.ok(ApiResponse.success("수강신청 목록 조회", response));
+    }
+
+    //특정 강의 수강신청 인원 수 조회
+    @GetMapping("/{lectureId}/count")
+    public ResponseEntity<ApiResponse<LectureEnrollCountResponse>> getLectureEnrollCount(@PathVariable Long lectureId) {
+        LectureEnrollCountResponse response = lectureMemberQueryService.getLectureEnrollCount(lectureId);
+        return ResponseEntity.ok(ApiResponse.success("해당 강의 수강신청 인원 수 조회", response));
     }
 
     @PostMapping()

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/controller/LectureMemberController.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/controller/LectureMemberController.java
@@ -3,6 +3,8 @@ package github.nbcamp.lectureflow.domain.lectureMember.controller;
 
 import github.nbcamp.lectureflow.domain.lectureMember.dto.request.CreateLectureMemberRequest;
 import github.nbcamp.lectureflow.domain.lectureMember.dto.response.CreateLectureMemberResponse;
+import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureMemberListResponse;
+import github.nbcamp.lectureflow.domain.lectureMember.service.LectureMemberQueryService;
 import github.nbcamp.lectureflow.domain.lectureMember.service.LectureMemberService;
 import github.nbcamp.lectureflow.global.dto.ApiResponse;
 import jakarta.validation.Valid;
@@ -11,13 +13,22 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/lectures/enroll")
 public class LectureMemberController {
 
     private final LectureMemberService lectureMemberService;
+    private final LectureMemberQueryService lectureMemberQueryService;
 
+    //로그인한 사용자의 수강신청 목록 조회
+    @GetMapping()
+    public ResponseEntity<ApiResponse<List<LectureMemberListResponse>>> getLectureMember(@AuthenticationPrincipal Long memberId) {
+        List<LectureMemberListResponse> response = lectureMemberQueryService.getLectureMember(memberId);
+        return ResponseEntity.ok(ApiResponse.success("수강신청 목록 조회", response));
+    }
 
     @PostMapping()
     public ResponseEntity<ApiResponse<CreateLectureMemberResponse>> createLectureMember(@Valid @RequestBody CreateLectureMemberRequest request, @AuthenticationPrincipal Long memberId) {

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/dto/response/LectureEnrollCountResponse.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/dto/response/LectureEnrollCountResponse.java
@@ -1,0 +1,23 @@
+package github.nbcamp.lectureflow.domain.lectureMember.dto.response;
+
+
+import lombok.Getter;
+
+@Getter
+public class LectureEnrollCountResponse {
+    private Long lectureId;
+    private int maxStudent;
+    private int student;
+
+    // JPQL COUNT 결과(Long)를 int로 변환하는 생성자.
+    public LectureEnrollCountResponse(Long lectureId, int maxStudent, Long student){
+        this.lectureId=lectureId;
+        this.maxStudent=maxStudent;
+        this.student=student.intValue();
+    }
+
+    public static LectureEnrollCountResponse of(Long lectureId, int maxStudent, Long student) {
+        return new LectureEnrollCountResponse(lectureId, maxStudent, student);
+    }
+}
+

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/dto/response/LectureMemberListResponse.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/dto/response/LectureMemberListResponse.java
@@ -1,0 +1,53 @@
+package github.nbcamp.lectureflow.domain.lectureMember.dto.response;
+
+import github.nbcamp.lectureflow.global.enums.Day;
+import github.nbcamp.lectureflow.global.enums.Department;
+import github.nbcamp.lectureflow.global.enums.MajorOrGeneral;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+    @Getter
+    @AllArgsConstructor
+    public class LectureMemberListResponse {
+
+        private Long id;
+        private Long lectureId;
+        private String lectureName;
+        private MajorOrGeneral majorOrGeneral;
+        private int gradeLevel;
+        private Department department;
+        private int classroom;
+        private Day day;
+        private String professor;
+        private int maxStudent;
+        private boolean isRetake;
+
+
+        public static LectureMemberListResponse of(
+                Long id,
+                Long lectureId,
+                String lectureName,
+                MajorOrGeneral majorOrGeneral,
+                int gradeLevel,
+                Department department,
+                int classroom,
+                Day day,
+                String professor,
+                int maxStudent,
+                boolean isRetake
+        ) {
+            return new LectureMemberListResponse(
+                    id,
+                    lectureId,
+                    lectureName,
+                    majorOrGeneral,
+                    gradeLevel,
+                    department,
+                    classroom,
+                    day,
+                    professor,
+                    maxStudent,
+                    isRetake
+            );
+        }
+    }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/repository/LectureMemberQueryRepository.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/repository/LectureMemberQueryRepository.java
@@ -1,5 +1,6 @@
 package github.nbcamp.lectureflow.domain.lectureMember.repository;
 
+import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureEnrollCountResponse;
 import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureMemberListResponse;
 import github.nbcamp.lectureflow.global.entity.LectureMember;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,15 @@ public interface LectureMemberQueryRepository extends JpaRepository<LectureMembe
     WHERE lm.member.id = :memberId
 """)
     List<LectureMemberListResponse> getLectureMember(@Param("memberId") Long memberId);
+
+
+    @Query("""
+        SELECT l.id, l.maxStudent, COUNT (lm)
+        FROM LectureMember lm
+        JOIN lm.lecture l
+        WHERE l.id = :lectureId
+        GROUP BY l.id, l.maxStudent
+""")
+    LectureEnrollCountResponse getLectureEnrollCount(@Param("lectureId") Long lectureId);
 }
+

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/repository/LectureMemberQueryRepository.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/repository/LectureMemberQueryRepository.java
@@ -1,0 +1,21 @@
+package github.nbcamp.lectureflow.domain.lectureMember.repository;
+
+import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureMemberListResponse;
+import github.nbcamp.lectureflow.global.entity.LectureMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface LectureMemberQueryRepository extends JpaRepository<LectureMember,Long> {
+
+    @Query("""
+    SELECT lm.id, l.id, l.lectureName, l.majorOrGeneral, l.gradeLevel,
+        l.department, l.classroom, l.day, l.professor, l.maxStudent, lm.isRetake
+    FROM LectureMember lm
+    JOIN lm.lecture l
+    WHERE lm.member.id = :memberId
+""")
+    List<LectureMemberListResponse> getLectureMember(@Param("memberId") Long memberId);
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberQueryService.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberQueryService.java
@@ -1,5 +1,6 @@
 package github.nbcamp.lectureflow.domain.lectureMember.service;
 
+import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureEnrollCountResponse;
 import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureMemberListResponse;
 
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface LectureMemberQueryService {
 
     List<LectureMemberListResponse> getLectureMember(Long memberId);
+
+    LectureEnrollCountResponse getLectureEnrollCount(Long lectureId);
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberQueryService.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberQueryService.java
@@ -1,0 +1,10 @@
+package github.nbcamp.lectureflow.domain.lectureMember.service;
+
+import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureMemberListResponse;
+
+import java.util.List;
+
+public interface LectureMemberQueryService {
+
+    List<LectureMemberListResponse> getLectureMember(Long memberId);
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberQueryServiceImpl.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package github.nbcamp.lectureflow.domain.lectureMember.service;
+
+import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureMemberListResponse;
+import github.nbcamp.lectureflow.domain.lectureMember.repository.LectureMemberQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LectureMemberQueryServiceImpl implements LectureMemberQueryService{
+
+
+    private final LectureMemberQueryRepository lectureMemberQueryRepository;
+
+    @Override
+    public List<LectureMemberListResponse> getLectureMember(Long memberId) {
+        return lectureMemberQueryRepository.getLectureMember(memberId);
+    }
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberQueryServiceImpl.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package github.nbcamp.lectureflow.domain.lectureMember.service;
 
+import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureEnrollCountResponse;
 import github.nbcamp.lectureflow.domain.lectureMember.dto.response.LectureMemberListResponse;
 import github.nbcamp.lectureflow.domain.lectureMember.repository.LectureMemberQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,4 +19,11 @@ public class LectureMemberQueryServiceImpl implements LectureMemberQueryService{
     public List<LectureMemberListResponse> getLectureMember(Long memberId) {
         return lectureMemberQueryRepository.getLectureMember(memberId);
     }
+
+    @Override
+    public LectureEnrollCountResponse getLectureEnrollCount(Long lectureId) {
+        return lectureMemberQueryRepository.getLectureEnrollCount(lectureId);
+    }
+
+
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberServiceImpl.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/service/LectureMemberServiceImpl.java
@@ -62,7 +62,7 @@ public class LectureMemberServiceImpl implements LectureMemberService {
         //수강 신청
         lectureMemberRepository.save(lectureMember);
 
-        return new CreateLectureMemberResponse(lectureMember.getLectureMemberId(), memberId, lecture.getId());
+        return new CreateLectureMemberResponse(lectureMember.getId(), memberId, lecture.getId());
     }
 
     @Transactional

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
@@ -13,7 +13,7 @@ public class LectureMember extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     //수강신청 내역 고유 ID
-    @Column(name = "lecture_member_id", nullable = false)
+    @Column(nullable = false)
     private Long id;
 
     //학생(member)

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/LectureMember.java
@@ -14,7 +14,7 @@ public class LectureMember extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     //수강신청 내역 고유 ID
     @Column(name = "lecture_member_id", nullable = false)
-    private Long lectureMemberId;
+    private Long id;
 
     //학생(member)
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 이슈 번호
#20
## 작업 내용
- 로그인한 사용자가 수강신청한 목록을 조회하는 api 구현
- 특정 강의 수강신청한 인원을 조회하는 api 구현
- JPQL 사용
## 스크린샷(선택)
- 수강신청 목록 조회
<img width="508" height="664" alt="image" src="https://github.com/user-attachments/assets/ef6a1bdb-096a-4903-9e88-15a1fe4fc811" />

- 특정 강의 수강신청한 인원 조회
<img width="517" height="255" alt="image" src="https://github.com/user-attachments/assets/6dbad0fb-0ff6-4c49-9a7c-1fec08877195" />

