### PR TITLE
Feat: 인메모리캐시 -> 레디스 변경 및 캐시 동기화 문제 해결

### DIFF
--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/LectureFlowApplication.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/LectureFlowApplication.java
@@ -7,9 +7,7 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
-@EnableCaching
 @SpringBootApplication
-@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class LectureFlowApplication {
 
     public static void main(String[] args) {

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/request/SignupRequest.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/auth/dto/request/SignupRequest.java
@@ -1,6 +1,6 @@
 package github.nbcamp.lectureflow.domain.auth.dto.request;
 
-import github.nbcamp.lectureflow.domain.user.enums.Role;
+import github.nbcamp.lectureflow.domain.member.enums.Role;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/keyword/service/KeywordServiceImpl.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/keyword/service/KeywordServiceImpl.java
@@ -4,6 +4,7 @@ import github.nbcamp.lectureflow.domain.keyword.dto.TopTenResponse;
 import github.nbcamp.lectureflow.domain.keyword.repository.KeywordRepository;
 import github.nbcamp.lectureflow.global.entity.Keyword;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -43,4 +44,8 @@ public class KeywordServiceImpl implements KeywordService {
     public void deleteOldKeywords() {
         keywordRepository.deleteOldKeywords();
     }
+
+    @Scheduled(fixedRate = 1800000) // 30분
+    @CacheEvict(value = "topKeywords", allEntries = true)
+    public void evictTopKeywordsCache() {}
 }

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/dto/request/LectureSearchCondition.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/dto/request/LectureSearchCondition.java
@@ -1,6 +1,6 @@
 package github.nbcamp.lectureflow.domain.lecture.dto.request;
 
-import github.nbcamp.lectureflow.global.enums.MajorOrGeneral;
+import github.nbcamp.lectureflow.domain.lecture.enums.MajorOrGeneral;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/dto/request/LectureUpdateRequestDto.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/dto/request/LectureUpdateRequestDto.java
@@ -1,8 +1,8 @@
 package github.nbcamp.lectureflow.domain.lecture.dto.request;
 
-import github.nbcamp.lectureflow.global.enums.Day;
-import github.nbcamp.lectureflow.global.enums.Department;
-import github.nbcamp.lectureflow.global.enums.MajorOrGeneral;
+import github.nbcamp.lectureflow.domain.lecture.enums.Day;
+import github.nbcamp.lectureflow.domain.lecture.enums.Department;
+import github.nbcamp.lectureflow.domain.lecture.enums.MajorOrGeneral;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import java.time.LocalTime;

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/dto/request/LectureUploadRequestDto.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/dto/request/LectureUploadRequestDto.java
@@ -1,8 +1,8 @@
 package github.nbcamp.lectureflow.domain.lecture.dto.request;
 
-import github.nbcamp.lectureflow.global.enums.Day;
-import github.nbcamp.lectureflow.global.enums.Department;
-import github.nbcamp.lectureflow.global.enums.MajorOrGeneral;
+import github.nbcamp.lectureflow.domain.lecture.enums.Day;
+import github.nbcamp.lectureflow.domain.lecture.enums.Department;
+import github.nbcamp.lectureflow.domain.lecture.enums.MajorOrGeneral;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/dto/response/LectureDetailResponse.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/dto/response/LectureDetailResponse.java
@@ -3,9 +3,9 @@ package github.nbcamp.lectureflow.domain.lecture.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.querydsl.core.annotations.QueryProjection;
 import github.nbcamp.lectureflow.global.entity.Lecture;
-import github.nbcamp.lectureflow.global.enums.Day;
-import github.nbcamp.lectureflow.global.enums.Department;
-import github.nbcamp.lectureflow.global.enums.MajorOrGeneral;
+import github.nbcamp.lectureflow.domain.lecture.enums.Day;
+import github.nbcamp.lectureflow.domain.lecture.enums.Department;
+import github.nbcamp.lectureflow.domain.lecture.enums.MajorOrGeneral;
 import lombok.Getter;
 
 import java.time.LocalTime;

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/enums/Day.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/enums/Day.java
@@ -1,4 +1,4 @@
-package github.nbcamp.lectureflow.global.enums;
+package github.nbcamp.lectureflow.domain.lecture.enums;
 
 import lombok.Getter;
 

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/enums/Department.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/enums/Department.java
@@ -1,4 +1,4 @@
-package github.nbcamp.lectureflow.global.enums;
+package github.nbcamp.lectureflow.domain.lecture.enums;
 
 import lombok.Getter;
 

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/enums/MajorOrGeneral.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/enums/MajorOrGeneral.java
@@ -1,4 +1,4 @@
-package github.nbcamp.lectureflow.global.enums;
+package github.nbcamp.lectureflow.domain.lecture.enums;
 
 import lombok.Getter;
 

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/service/FileUpload.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lecture/service/FileUpload.java
@@ -2,13 +2,13 @@ package github.nbcamp.lectureflow.domain.lecture.service;
 
 import github.nbcamp.lectureflow.domain.lecture.dto.request.LectureUploadRequestDto;
 import github.nbcamp.lectureflow.domain.lecture.exception.LectureException;
-import github.nbcamp.lectureflow.global.enums.Day;
-import github.nbcamp.lectureflow.global.enums.Department;
-import github.nbcamp.lectureflow.global.enums.MajorOrGeneral;
+import github.nbcamp.lectureflow.domain.lecture.enums.Day;
+import github.nbcamp.lectureflow.domain.lecture.enums.Department;
+import github.nbcamp.lectureflow.domain.lecture.enums.MajorOrGeneral;
 import github.nbcamp.lectureflow.global.exception.ErrorCode;
 import org.apache.poi.openxml4j.exceptions.NotOfficeXmlFileException;
 import org.apache.poi.ss.usermodel.*;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.DateTimeException;

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/dto/response/LectureMemberListResponse.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/lectureMember/dto/response/LectureMemberListResponse.java
@@ -1,8 +1,8 @@
 package github.nbcamp.lectureflow.domain.lectureMember.dto.response;
 
-import github.nbcamp.lectureflow.global.enums.Day;
-import github.nbcamp.lectureflow.global.enums.Department;
-import github.nbcamp.lectureflow.global.enums.MajorOrGeneral;
+import github.nbcamp.lectureflow.domain.lecture.enums.Day;
+import github.nbcamp.lectureflow.domain.lecture.enums.Department;
+import github.nbcamp.lectureflow.domain.lecture.enums.MajorOrGeneral;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/response/MemberResponseDto.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/dto/response/MemberResponseDto.java
@@ -1,7 +1,7 @@
 package github.nbcamp.lectureflow.domain.member.dto.response;
 
 import github.nbcamp.lectureflow.global.entity.Member;
-import github.nbcamp.lectureflow.domain.user.enums.Role;
+import github.nbcamp.lectureflow.domain.member.enums.Role;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/enums/Role.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/member/enums/Role.java
@@ -1,0 +1,7 @@
+package github.nbcamp.lectureflow.domain.member.enums;
+
+public enum Role {
+
+    ADMIN, STUDENT
+
+}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/user/enums/Role.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/domain/user/enums/Role.java
@@ -1,7 +1,0 @@
-package github.nbcamp.lectureflow.domain.user.enums;
-
-public enum Role {
-
-    ADMIN, STUDENT
-
-}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/config/CacheConfig.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/config/CacheConfig.java
@@ -1,9 +1,0 @@
-package github.nbcamp.lectureflow.global.config;
-
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@EnableCaching
-public class CacheConfig {
-}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/config/PageConfig.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/config/PageConfig.java
@@ -1,0 +1,10 @@
+package github.nbcamp.lectureflow.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
+public class PageConfig {
+}
+

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/config/RedisConfig.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/config/RedisConfig.java
@@ -3,22 +3,36 @@ package github.nbcamp.lectureflow.global.config;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 @EnableCaching
 public class RedisConfig {
 
+    private static final int CACHE_TTL = 60 * 30; // 30 분
+
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new GenericJackson2JsonRedisSerializer()
-                ));
+                .disableCachingNullValues() // null 캐싱 X
+                .entryTtl(Duration.ofSeconds(CACHE_TTL))
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new StringRedisSerializer()))
+
+                .serializeValuesWith(RedisSerializationContext
+                        .SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(config)
                 .build();

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/config/RedisConfig.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package github.nbcamp.lectureflow.global.config;
 
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -9,6 +10,7 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 
 @Configuration
+@EnableCaching
 public class RedisConfig {
 
     @Bean

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Lecture.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Lecture.java
@@ -1,9 +1,9 @@
 package github.nbcamp.lectureflow.global.entity;
 
 import github.nbcamp.lectureflow.domain.lecture.dto.request.LectureUploadRequestDto;
-import github.nbcamp.lectureflow.global.enums.Day;
-import github.nbcamp.lectureflow.global.enums.Department;
-import github.nbcamp.lectureflow.global.enums.MajorOrGeneral;
+import github.nbcamp.lectureflow.domain.lecture.enums.Day;
+import github.nbcamp.lectureflow.domain.lecture.enums.Department;
+import github.nbcamp.lectureflow.domain.lecture.enums.MajorOrGeneral;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Member.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/entity/Member.java
@@ -1,6 +1,6 @@
 package github.nbcamp.lectureflow.global.entity;
 
-import github.nbcamp.lectureflow.domain.user.enums.Role;
+import github.nbcamp.lectureflow.domain.member.enums.Role;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/enums/Role.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/enums/Role.java
@@ -1,6 +1,0 @@
-package github.nbcamp.lectureflow.global.enums;
-
-public enum Role {
-    ADMIN,
-    STUDENT
-}

--- a/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/filter/JwtUtil.java
+++ b/LectureFlow/src/main/java/github/nbcamp/lectureflow/global/filter/JwtUtil.java
@@ -1,6 +1,6 @@
 package github.nbcamp.lectureflow.global.filter;
 
-import github.nbcamp.lectureflow.domain.user.enums.Role;
+import github.nbcamp.lectureflow.domain.member.enums.Role;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;

--- a/LectureFlow/src/test/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImplTest.java
+++ b/LectureFlow/src/test/java/github/nbcamp/lectureflow/domain/auth/service/AuthServiceImplTest.java
@@ -6,7 +6,7 @@ import github.nbcamp.lectureflow.domain.auth.dto.response.SigninResponse;
 import github.nbcamp.lectureflow.domain.auth.dto.response.SignupResponse;
 import github.nbcamp.lectureflow.domain.auth.exception.AuthException;
 import github.nbcamp.lectureflow.domain.auth.repository.AuthRepository;
-import github.nbcamp.lectureflow.domain.user.enums.Role;
+import github.nbcamp.lectureflow.domain.member.enums.Role;
 import github.nbcamp.lectureflow.global.entity.Member;
 import github.nbcamp.lectureflow.global.filter.JwtUtil;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 이슈 번호
#36 

## 작업 내용
<img width="699" height="441" alt="image" src="https://github.com/user-attachments/assets/228b3417-9ad4-47b3-8d6d-5ad9dfb0ae2b" />
서버를 여러 대로 확장(Scale-Out)했을 때 각 WAS 서버는 자신의 메모리에만 캐시를 저장하기 때문에 서로의 캐시 정보를 공유할 수 없습니다. 이로 인해 데이터 일관성 문제가 발생할 수 있습니다. 
-> redis 적용

<img width="730" height="249" alt="image" src="https://github.com/user-attachments/assets/d16e0c3f-1393-4f42-aa76-d86c164853c1" />
캐시 히트 시 매번 캐시에서만 데이터를 읽어오게 되는데, 이 경우 DB 값이 변경되었더라도 캐시 데이터가 동기화되지 않으면 오래된 정보를 불러오는 문제가 발생할 수 있습니다. 이를 방지하기 위해 주기적으로 캐시를 무효화하는 로직을 구현하였고, 학습 차원에서 @CacheEvict와 TTL(Time-To-Live) 설정을 함께 적용해 보았습니다.

### @CacheEvict + @Scheduled
<img width="464" height="79" alt="image" src="https://github.com/user-attachments/assets/ed7dc55c-caee-47d6-92e8-f1d7a79671cd" />

### TTL config
<img width="645" height="156" alt="image" src="https://github.com/user-attachments/assets/737d842f-beae-445f-8fe2-d64f321d4a9a" />



## 스크린샷(선택)